### PR TITLE
For discussion: Track and end sockets associated with clientKeys

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -220,6 +220,7 @@ class HttpRequestManager extends EventEmitter{
   init(options){
     options = options || {};
     this.http2Clients = {};
+    this.http2Sockets = {};
     this.cachedHTTP1Result = {};
     this.setModules();
     this.http2Debouncer = new DebounceTimers(function stopConnection(key){
@@ -227,6 +228,10 @@ class HttpRequestManager extends EventEmitter{
       var foundConnection = this.http2Clients[key];
       if (foundConnection){
         this.removeHttp2Client(key , foundConnection)
+      }
+      var foundSocket = this.http2Sockets[key];
+      if (foundSocket){
+        this.removeHttp2Socket(key , foundSocket);
       }
     }.bind(this) , 1000);
 
@@ -318,6 +323,15 @@ class HttpRequestManager extends EventEmitter{
     client.removeAllListeners('frameError');
     client.removeAllListeners('timeout');
   }
+  removeHttp2Socket(clientKey, socket) {
+    let host = clientKey.split(':')[1];
+    for (let key in this.http2Sockets) {
+      if (key.split(':')[1] === host) {
+        this.http2Sockets[key].end();
+        delete this.http2Sockets[key];
+      }
+    }
+  }
   request(url, options, cb){
     var args = new RequestInternalEnforce(arguments);
     if (this.enforceProtocol){
@@ -362,6 +376,7 @@ class HttpRequestManager extends EventEmitter{
       //We will need to start identification
       this.once(topic , function letKnowThereIsAnEvent(){}); //There is.. let's wait
       const socket = this.identifyConnection(requestOptions , function onIdentify(type){
+        this.http2Sockets[clientKey] = socket;
         var options = {
           createConnection(){
             return socket;
@@ -381,7 +396,6 @@ class HttpRequestManager extends EventEmitter{
         this.emit(topic , options);
       }.bind(this))
     }
-    
   }
   makeHttpRequest(clientKey , inStream , options , cb , connectionOptions){
     if (options instanceof URL)
@@ -481,7 +495,7 @@ class HttpRequestManager extends EventEmitter{
            socket = this.tls.connect(port, host, initializeTLSOptions.call(this , options, host) , listener);
           break;
         default:
-          throw new Error('Not supprted' + protocol);
+          throw new Error('Not supported' + protocol);
       }
     }
     return socket;


### PR DESCRIPTION
I'm seeing behaviour where programs hang once `http` or `https` requests are replaced with this library and no other changes are made.

Debugging it seems to point to `TLSSocket`s being left open, so in this PR I've added explicit tracking and `end`ing of those sockets.

I'd like your thoughts on this. Happy to fold the `http2Sockets` into a better structure with `http2Clients` maybe?

Bonus typo fixed too.