### PR TITLE
Replace dynamic requires with static ones to not break webpack

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -246,24 +246,19 @@ class HttpRequestManager extends EventEmitter{
       this.enforceProtocol = 'https:';
     }
   }
-  setModules(){
-    [
-        'http',
-        'https',
-        'tls',
-        'net'
-    ].forEach(mName => this.loadModule(mName));
+  setModules() {
+    this['http'] = require('http');
+    this['https'] = require('https');
+    this['tls'] = require('tls');
+    this['net'] = require('net');
     this.http2Support = false;
     try{
-      this.loadModule('http2');
+      this['http2'] = require('http2');
       this.http2Support = true;
     }
     catch(err){
       //It will automatically fallback to http
     }
- }
- loadModule(name){
-    this[name] = require(name);
   }
   handleClientRequest(clientRequest , requestOptions ,cb){
     const requestManager = this;


### PR DESCRIPTION
I had issues using this package together with webpack, because of the dynamic/programmatic requires. 
I'm not really sure what setModules is trying to accomplish, but hope this is ok. 